### PR TITLE
Added support for cockroachdb v19.1.0

### DIFF
--- a/src/nkpgsql.erl
+++ b/src/nkpgsql.erl
@@ -153,6 +153,9 @@ do_query(Pid, Query, QueryMeta) when is_pid(Pid) ->
         {error, {pgsql_error, #{code := <<"XX000">>}}=Error} ->
             ?LLOG(notice, "no_transaction PGSQL error: ~p\n~s", [Error, list_to_binary([Query])]),
             throw(no_transaction);
+        {error, {pgsql_error, #{code := <<"XXUUU">>}}=Error} ->
+            ?LLOG(notice, "no_transaction PGSQL error: ~p\n~s", [Error, list_to_binary([Query])]),
+            throw(no_transaction);
         {error, {pgsql_error, #{code := <<"42P01">>}}} ->
             throw(relation_unknown);
         {error, {pgsql_error, #{code := <<"42601">>}}=Error} ->


### PR DESCRIPTION
"Regular SQL errors that indicate erroneous SQL and for which CockroachDB does not yet populate a well-defined PostgreSQL error code will now be reported with code XXUUU instead of code XX000."

More info at: https://www.cockroachlabs.com/docs/releases/v19.1.0-rc.1.html